### PR TITLE
locale_in_accept_languageの返り値を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
   # 環境変数HTTP_ACCEPT_LANGUAGEを順に検証し、最初に一致した有効なlocaleを返す
   def locale_in_accept_language
     i18n_languages = I18n.available_locales.map(&:to_s)
+
     request.env['HTTP_ACCEPT_LANGUAGE']
            .to_s
            .split(',')
@@ -30,6 +31,8 @@ class ApplicationController < ActionController::Base
         return i18n_lang if accept_lang.start_with?(i18n_lang)
       end
     end
+
+    nil
   end
 
   def default_url_options(options = {})


### PR DESCRIPTION
`locale_in_accept_language` でマッチするlocaleが見つからなかった場合 `nil` を返すよう修正します。